### PR TITLE
EXT-1863: Keep the NuxtJS layout equal to the NextJS

### DIFF
--- a/app-nuxtjs-3-starter/assets/main.css
+++ b/app-nuxtjs-3-starter/assets/main.css
@@ -1,19 +1,24 @@
-html{
-    height:100%;
+html {
+  height: 100%;
 }
 
 body {
-    font-size: 0.875rem;
-    padding: 0;
-    margin: 0;
-    font-family: Roboto, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
-    line-height: 1.6;
-    color: #1b243f;
-    height:100%;
+  font-size: 0.875rem;
+  padding: 0;
+  margin: 0;
+  font-family: Roboto, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+    Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  line-height: 1.6;
+  color: #1b243f;
+  height: 100%;
 }
 
 body > div {
-    height: 100%;
-    display:flex;
+  height: 100%;
+  display: flex;
+}
+
+a {
+  color: #009f9c;
+  text-decoration: none;
 }

--- a/app-nuxtjs-3-starter/components/Header.vue
+++ b/app-nuxtjs-3-starter/components/Header.vue
@@ -1,9 +1,22 @@
 <template>
   <header class="header">
-    <StoryblokIcon />
+    <div class="header__icon">
+      <StoryblokIcon />
+    </div>
     <div class="header__titles">
       <h1 class="header__title">Nuxt Custom Application</h1>
-      <h2 class="header__subtitle">Subtitle</h2>
+      <h2 class="header__subtitle">
+        Created with
+        <code>
+          <a
+            class="header__link"
+            target="_blank"
+            href="https://www.npmjs.com/package/@storyblok/app-extension-auth"
+            >@storyblok/app-extension-auth</a
+          >
+        </code>
+        .
+      </h2>
     </div>
   </header>
 </template>
@@ -12,9 +25,13 @@
 .header {
   display: flex;
   flex-direction: row;
-  gap: 10px 15px;
-  margin-bottom: 50px;
+  gap: 10px;
+  margin-bottom: 45px;
   align-items: flex-start;
+}
+
+.header__icon {
+  margin-top: 8px;
 }
 
 .header__titles {
@@ -33,10 +50,15 @@
 }
 
 .header__subtitle {
-  margin: 0;
+  display: flex;
+  margin: 0 0 0 2px;
   font-weight: 400;
   letter-spacing: 0.00714em;
   color: #8d919f;
   font-size: 0.875rem;
+}
+
+.header__link {
+  padding: 0 0 0 0.25rem;
 }
 </style>

--- a/app-nuxtjs-3-starter/components/StoryTable.vue
+++ b/app-nuxtjs-3-starter/components/StoryTable.vue
@@ -61,13 +61,13 @@ const formattedDate = (date: string) => {
 
 <style scoped>
 .table {
-  width: 100%;
   border-collapse: collapse;
+  width: 100%;
 }
 
 .table__head-cell {
   box-sizing: border-box;
-  padding: 14px 10px;
+  padding: 14px 0;
   color: #8d919f;
   font-weight: 400;
   line-height: 1.3;
@@ -85,7 +85,7 @@ const formattedDate = (date: string) => {
 .table__data-cell {
   color: #8d919f;
   gap: 20px;
-  padding: 14px 10px;
+  padding: 14px 0;
 }
 
 .table__data-cell--name {
@@ -109,4 +109,5 @@ const formattedDate = (date: string) => {
     display: none;
   }
 }
+
 </style>

--- a/app-nuxtjs-3-starter/pages/401.vue
+++ b/app-nuxtjs-3-starter/pages/401.vue
@@ -10,7 +10,7 @@ onMounted(() => {
   <div class="error">
     <UnauthorizedIcon />
     <h3 class="error__title">Unauthorized</h3>
-    <h4 class="error_subtitle">Failed to authenticate</h4>
+    <h4 class="error__subtitle">Failed to authenticate</h4>
   </div>
 </template>
 
@@ -33,7 +33,7 @@ onMounted(() => {
   line-height: 1.167;
 }
 
-.error_subtitle {
+.error__subtitle {
   margin: 0;
   font-weight: 400;
   letter-spacing: 0.00938em;


### PR DESCRIPTION
Issue: EXT-1863

### What?
Adjust the NuxtJS starter example to look the same as the NextJS. So, minors layout changes were made such as:

- A subtitle was added;
- Header's margins/paddings were adjusted;

### Before

"Desktop" version
<img width="1233" alt="image" src="https://github.com/storyblok/custom-app-examples/assets/1240591/c0cae67c-b09b-4136-ab33-af5ef4dbd032">

"Mobile" version
<img width="541" alt="image" src="https://github.com/storyblok/custom-app-examples/assets/1240591/156aeb73-679d-4b8f-8332-56a7850eb762">


### After

"Desktop" version
<img width="1225" alt="image" src="https://github.com/storyblok/custom-app-examples/assets/1240591/b316e913-e06b-4cfc-9e82-acf41fd5d324">

"Mobile" version
<img width="552" alt="image" src="https://github.com/storyblok/custom-app-examples/assets/1240591/fdf1b15f-268b-4c86-aecc-b3d0771bd0ed">