### PR TITLE
fix: include `storyblok` in the callback URL

### DIFF
--- a/app-nextjs-starter/src/auth.ts
+++ b/app-nextjs-starter/src/auth.ts
@@ -1,6 +1,6 @@
 import { AuthHandlerParams } from '@storyblok/app-extension-auth'
 
-export const endpointPrefix = '/api/authenticate'
+export const endpointPrefix = '/api/authenticate/storyblok'
 
 export const authHandlerParams: AuthHandlerParams = {
   clientId: process.env.CLIENT_ID,

--- a/app-nextjs-starter/src/components/Header.tsx
+++ b/app-nextjs-starter/src/components/Header.tsx
@@ -8,7 +8,7 @@ export const Header = () => {
         <StoryblokIcon />
       </div>
       <div className={styles.header__titles}>
-        <h1 className={styles.header__title}>Next Custom Application</h1>
+        <h1 className={styles.header__title}>Next.js Plugin</h1>
         <h2 className={styles.header__subtitle}>
           Created with
           <code>


### PR DESCRIPTION
The instructions include `storyblok` in the callback URL, but the source code is not including `storyblok` in the `endpointPrefix`. This causes authentication error. The solution here is append `/storyblok` to the `endpointPrefix`. 

Another solution would have been to change the instructions