### PR TITLE
fix: remove `isLastAuthor` validation

### DIFF
--- a/app-nextjs-starter/src/Story.ts
+++ b/app-nextjs-starter/src/Story.ts
@@ -23,8 +23,7 @@ export const isStory = (data: unknown): data is Story =>
   'slug' in data &&
   typeof data.slug === 'string' &&
   'updated_at' in data &&
-  typeof data.updated_at === 'string' &&
-  'last_author' in data
+  typeof data.updated_at === 'string'
 
 export const isStories = (data: unknown): data is Story[] =>
   Array.isArray(data) && data.every(isStory)

--- a/app-nextjs-starter/src/Story.ts
+++ b/app-nextjs-starter/src/Story.ts
@@ -11,12 +11,6 @@ export type Story = {
   last_author: LastAuthor
 }
 
-const isLastAuthor = (data: unknown): data is LastAuthor =>
-  typeof data === 'object' &&
-  data !== null &&
-  'friendly_name' in data &&
-  typeof data.friendly_name === 'string'
-
 export const isStory = (data: unknown): data is Story =>
   typeof data === 'object' &&
   data !== null &&
@@ -30,8 +24,7 @@ export const isStory = (data: unknown): data is Story =>
   typeof data.slug === 'string' &&
   'updated_at' in data &&
   typeof data.updated_at === 'string' &&
-  'last_author' in data &&
-  isLastAuthor(data.last_author)
+  'last_author' in data
 
 export const isStories = (data: unknown): data is Story[] =>
   Array.isArray(data) && data.every(isStory)

--- a/app-nextjs-starter/src/components/StoryTable.tsx
+++ b/app-nextjs-starter/src/components/StoryTable.tsx
@@ -61,7 +61,7 @@ export const StoryTable: FunctionComponent<{
               <td
                 className={`${styles['table__data-cell']} ${styles['table__data-cell--author']}`}
               >
-                {story.last_author.friendly_name}
+                {story.last_author?.friendly_name || '-'}
               </td>
               <td className={styles['table__data-cell']}>
                 {formattedDate(story.updated_at)}

--- a/app-nuxtjs-3-starter/components/StoryTable.vue
+++ b/app-nuxtjs-3-starter/components/StoryTable.vue
@@ -42,14 +42,13 @@ const formattedDate = (date: string) => {
         <td class="table__data-cell table__data-cell--name">
           <FolderIcon v-if="story.is_folder" />
           <StoryIcon v-else />
-
           <div class="table__data-cell-name">
             <strong class="table__story-name">{{ story.name }}</strong>
             <span>{{ story.slug }}</span>
           </div>
         </td>
         <td class="table__data-cell table__data-cell--author">
-          {{ story.last_author.friendly_name }}
+          {{ story.last_author?.friendly_name || '-' }}
         </td>
         <td class="table__data-cell">
           {{ formattedDate(story.updated_at) }}
@@ -109,5 +108,4 @@ const formattedDate = (date: string) => {
     display: none;
   }
 }
-
 </style>

--- a/app-nuxtjs-3-starter/shared/types/story.ts
+++ b/app-nuxtjs-3-starter/shared/types/story.ts
@@ -23,8 +23,7 @@ export const isStory = (data: unknown): data is Story =>
   'slug' in data &&
   typeof data.slug === 'string' &&
   'updated_at' in data &&
-  typeof data.updated_at === 'string' &&
-  'last_author' in data
+  typeof data.updated_at === 'string'
 
 export const isStories = (data: unknown): data is Story[] =>
   Array.isArray(data) && data.every(isStory)

--- a/app-nuxtjs-3-starter/shared/types/story.ts
+++ b/app-nuxtjs-3-starter/shared/types/story.ts
@@ -11,12 +11,6 @@ export type Story = {
   last_author: LastAuthor
 }
 
-const isLastAuthor = (data: unknown): data is LastAuthor =>
-  typeof data === 'object' &&
-  data !== null &&
-  'friendly_name' in data &&
-  typeof data.friendly_name === 'string'
-
 export const isStory = (data: unknown): data is Story =>
   typeof data === 'object' &&
   data !== null &&
@@ -30,8 +24,7 @@ export const isStory = (data: unknown): data is Story =>
   typeof data.slug === 'string' &&
   'updated_at' in data &&
   typeof data.updated_at === 'string' &&
-  'last_author' in data &&
-  isLastAuthor(data.last_author)
+  'last_author' in data
 
 export const isStories = (data: unknown): data is Story[] =>
   Array.isArray(data) && data.every(isStory)


### PR DESCRIPTION
Ticket: EXT-1935
fixes #21

## What

Since for every newly created space, a default story is added automatically (home) and for this story, no `last_author` is provided, some adjustments were required to make it optional in our starter examples and does not break the page.

![Screenshot 2023-08-25 at 08 38 27](https://github.com/storyblok/custom-app-examples/assets/1240591/067b9b36-0a9e-40fc-9a5e-ce7d81bcd7ae)

![Screenshot 2023-08-25 at 08 37 51](https://github.com/storyblok/custom-app-examples/assets/1240591/4794422f-9194-452b-8e79-95bcb390439b)
