### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    allow:
+      - dependency-name: "@storyblok/region-helper"
+    reviewers:
+      - "storyblok/plugins-team"


### PR DESCRIPTION
# Summary

This PR adds dependabot configuration. However, I've allowed only `@storyblok/region-helper`. Otherwise, it will be too much to maintain all the dependencies of all our repositories. For now, the region helper is the most important one. So we can go with it only.
