### PR TITLE
chore: upgrade app-extension-auth to 1.0.3

### DIFF
--- a/app-nextjs-starter/package.json
+++ b/app-nextjs-starter/package.json
@@ -12,7 +12,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@storyblok/app-extension-auth": "1.0.2",
+    "@storyblok/app-extension-auth": "1.0.3",
     "next": "latest",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/app-nextjs-starter/yarn.lock
+++ b/app-nextjs-starter/yarn.lock
@@ -103,14 +103,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storyblok/app-extension-auth@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@storyblok/app-extension-auth@npm:1.0.2"
+"@storyblok/app-extension-auth@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@storyblok/app-extension-auth@npm:1.0.3"
   dependencies:
     "@storyblok/region-helper": 0.1.0
     jsonwebtoken: ^9.0.0
     openid-client: ^5.4.2
-  checksum: 7b89390cd48a3e770cd4ea85b220bd9d54d5fc5110475f9cc868f87f83df2ddf5a01171f2c931f7e5d4d39345e2c9ebc35148ce1ee9c7b1315c6786f2149f992
+  checksum: 53642504f45ebc30512f5af372b425b0d48b0713ab801500262827ee707d0582059c645958f87ba3d593a3742c2f499b087705c902e03fc761ed8901d6716b92
   languageName: node
   linkType: hard
 
@@ -166,7 +166,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "app-extension-nextjs-starter@workspace:."
   dependencies:
-    "@storyblok/app-extension-auth": 1.0.2
+    "@storyblok/app-extension-auth": 1.0.3
     "@types/node": 18.7.17
     "@types/react": 18.0.19
     next: latest

--- a/app-nuxtjs-3-starter/package.json
+++ b/app-nuxtjs-3-starter/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@storyblok/app-extension-auth": "1.0.2",
+    "@storyblok/app-extension-auth": "1.0.3",
     "prettier": "^2.8.8",
     "storyblok-js-client": "^5.10.5"
   },

--- a/app-nuxtjs-3-starter/yarn.lock
+++ b/app-nuxtjs-3-starter/yarn.lock
@@ -1069,14 +1069,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storyblok/app-extension-auth@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@storyblok/app-extension-auth@npm:1.0.2"
+"@storyblok/app-extension-auth@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@storyblok/app-extension-auth@npm:1.0.3"
   dependencies:
     "@storyblok/region-helper": 0.1.0
     jsonwebtoken: ^9.0.0
     openid-client: ^5.4.2
-  checksum: 7b89390cd48a3e770cd4ea85b220bd9d54d5fc5110475f9cc868f87f83df2ddf5a01171f2c931f7e5d4d39345e2c9ebc35148ce1ee9c7b1315c6786f2149f992
+  checksum: 53642504f45ebc30512f5af372b425b0d48b0713ab801500262827ee707d0582059c645958f87ba3d593a3742c2f499b087705c902e03fc761ed8901d6716b92
   languageName: node
   linkType: hard
 
@@ -5819,7 +5819,7 @@ __metadata:
   resolution: "nuxt-app@workspace:."
   dependencies:
     "@nuxtjs/eslint-config-typescript": ^12.0.0
-    "@storyblok/app-extension-auth": 1.0.2
+    "@storyblok/app-extension-auth": 1.0.3
     "@types/node": ^18
     "@typescript-eslint/eslint-plugin": latest
     "@typescript-eslint/parser": latest


### PR DESCRIPTION
# What

This PR upgrades `@storyblok/app-extension-auth` to v1.0.3.

# Why?

HTTP timeout update